### PR TITLE
Use CacheControl module for better caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ pytestdebug.log
 .coverage
 htmlcov/
 *.pyc
+Pipfile
+.webcache
+.testcache
+build/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,3 +6,4 @@ v0.1.3, 2018-07-10 -- Better python2 support; code style improvements
 v0.1.4, 2018-07-10 -- More python2 support
 v0.1.5, 2018-07-10 -- Ditto
 v0.1.6, 2018-08-01 -- Fix "domain undefined" error
+v1.0.0, 2019-01-16 -- Adds CacheControl awareness to cached sessions

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,9 @@ canonicalwebteam.http
 
 A Python library for making HTTP requests with sensible defaults
 
-.. image:: https://travis-ci.org/canonicalwebteam/http.svg?branch=master
+.. image:: https://travis-ci.org/canonical-webteam/http.svg?branch=master
    :alt: build status
-   :target: https://travis-ci.org/canonicalweeam/http
+   :target: https://travis-ci.org/canonical-webteam/http
 
 Installation
 ------------
@@ -16,3 +16,8 @@ This module is in PyPi as :code:`canonicalwebteam.http`. You should be able to i
 
     pip install canonicalwebteam.http
 
+
+Tests
+-----
+
+Tests are located in the `tests` directory and can be run with `python -m unittest discover tests/`.

--- a/canonicalwebteam/http/__init__.py
+++ b/canonicalwebteam/http/__init__.py
@@ -113,7 +113,7 @@ class CachedSession(BaseSession, Session):
     If CacheControl headers are not provided a custom duration time
     for caching can be passed as a fallback strategy.
 
-    :param redis_cache_pool: Port of your Redis instance
+    :param redis_connection_pool: Port of your Redis instance
     :param file_cache_directory: Name for the directory to store cache on
     :param fallback_cache_duration: Duration in seconds for fallback caching
         retention when no CacheControl headers are set
@@ -121,7 +121,7 @@ class CachedSession(BaseSession, Session):
 
     def __init__(
         self,
-        redis_cache_pool=None,
+        redis_connection_pool=None,
         fallback_cache_duration=5,
         file_cache_directory=".webcache",
         *args,
@@ -134,8 +134,8 @@ class CachedSession(BaseSession, Session):
         )
         cache = None
 
-        if redis_cache_pool:
-            r = redis.Redis(connection_pool=redis_cache_pool)
+        if redis_connection_pool:
+            r = redis.Redis(connection_pool=redis_connection_pool)
             cache = RedisCache(r)
         else:
             cache = FileCache(file_cache_directory)

--- a/canonicalwebteam/http/__init__.py
+++ b/canonicalwebteam/http/__init__.py
@@ -145,10 +145,11 @@ class CachedSession(BaseSession, Session):
         *args,
         **kwargs
     ):
+        super(CachedSession, self).__init__(*args, **kwargs)
+
         heuristic = ExpiresAfterIfNoCacheControl(
             seconds=fallback_cache_duration
         )
-        super(CachedSession, self).__init__(*args, **kwargs)
         cache = FileCache(file_cache_directory)
 
         if redis_connection:

--- a/canonicalwebteam/http/__init__.py
+++ b/canonicalwebteam/http/__init__.py
@@ -6,11 +6,11 @@ except ImportError:
 
 # Third-party packages
 import requests
-from cachecontrol import CacheControl, CacheControlAdapter
+from cachecontrol import CacheControlAdapter
 from cachecontrol.caches import FileCache
 from cachecontrol.caches.redis_cache import RedisCache
 from canonicalwebteam.http.heuristics import ExpiresAfterIfNoCacheControl
-from requests import adapters, session, Session
+from requests import adapters, Session
 
 try:
     # If prometheus is available, set up metric counters
@@ -51,7 +51,7 @@ class TimeoutHTTPAdapter(adapters.HTTPAdapter):
         return super(TimeoutHTTPAdapter, self).send(*args, **kwargs)
 
 
-class BaseSession(object):
+class BaseSession(Session):
     """
     A base session interface to implement common functionality:
 
@@ -110,13 +110,13 @@ class CacheAdapterWithTimeout(CacheControlAdapter):
 
     def __init__(self, heuristic, cache, timeout=None, *args, **kwargs):
         self.timeout = timeout
-        self.cache_control_adapter = CacheControlAdapter(
-            heuristic=heuristic, cache=cache
+        super(CacheAdapterWithTimeout, self).__init__(
+            cache=cache, heuristic=heuristic, *args, **kwargs
         )
 
     def send(self, *args, **kwargs):
         kwargs["timeout"] = self.timeout
-        return self.cache_control_adapter.send(*args, **kwargs)
+        return super(CacheAdapterWithTimeout, self).send(*args, **kwargs)
 
 
 class CachedSession(BaseSession, Session):

--- a/canonicalwebteam/http/heuristics.py
+++ b/canonicalwebteam/http/heuristics.py
@@ -54,7 +54,7 @@ class ExpiresAfterIfNoCacheControl(BaseHeuristic):
             "cache-control": "public",
         }
 
-    def warning(self,response):
+    def warning(self, response):
         """
         Adds a warning to the response as defined in rfc7234 section 5.5
         :param response: The response object to be manipulated.

--- a/canonicalwebteam/http/heuristics.py
+++ b/canonicalwebteam/http/heuristics.py
@@ -54,9 +54,10 @@ class ExpiresAfterIfNoCacheControl(BaseHeuristic):
             "cache-control": "public",
         }
 
-    def warning(self):
+    def warning(self,response):
         """
         Adds a warning to the response as defined in rfc7234 section 5.5
+        :param response: The response object to be manipulated.
         """
         template = "110 - Automatically cached for %s. Response might be stale"
         return template % self.delta

--- a/canonicalwebteam/http/heuristics.py
+++ b/canonicalwebteam/http/heuristics.py
@@ -1,0 +1,62 @@
+import calendar
+from cachecontrol.heuristics import BaseHeuristic
+from datetime import timedelta, datetime
+from email.utils import formatdate
+
+
+def expire_after(delta, date=None):
+    date = date or datetime.utcnow()
+    return date + delta
+
+
+def datetime_to_header(dt):
+    return formatdate(calendar.timegm(dt.timetuple()))
+
+
+def cache_control_value_present_in_response(headers, type):
+    """
+    checks if a certain CacheControl header is set in the headers
+    """
+    return "cache-control" in headers and type in headers["cache-control"]
+
+
+class ExpiresAfterIfNoCacheControl(BaseHeuristic):
+    """
+    Cache **all** requests for a defined time period.
+    """
+
+    def __init__(self, **kw):
+        self.delta = timedelta(**kw)
+
+    def update_headers(self, response):
+        def cc_value_in_response_headers(type):
+            return cache_control_value_present_in_response(
+                response.headers, type
+            )
+
+        if cc_value_in_response_headers(
+            "no-cache"
+        ) or cc_value_in_response_headers("max-age"):
+            return None
+
+        expires = expire_after(self.delta)
+
+        return {
+            "expires": datetime_to_header(expires),
+            "cache-control": "public",
+        }
+
+    def warning(self, response):
+        tmpl = "110 - Automatically cached for %s. Response might be stale"
+        return tmpl % self.delta
+
+    def apply(self, response):
+        updated_headers = self.update_headers(response)
+
+        if updated_headers:
+            response.headers.update(updated_headers)
+            warning_header_value = self.warning(response)
+            if warning_header_value is not None:
+                response.headers.update({"Warning": warning_header_value})
+
+        return response

--- a/canonicalwebteam/http/heuristics.py
+++ b/canonicalwebteam/http/heuristics.py
@@ -1,7 +1,7 @@
-import calendar
+import locale
+from datetime import datetime, timedelta
+
 from cachecontrol.heuristics import BaseHeuristic
-from datetime import timedelta, datetime
-from email.utils import formatdate
 
 
 def expire_after(delta, date=None):
@@ -9,17 +9,26 @@ def expire_after(delta, date=None):
     return date + delta
 
 
-def datetime_to_header(dt):
-    return formatdate(calendar.timegm(dt.timetuple()))
-
-
-def cache_control_in_response_headers(headers):
+def datetime_to_HTTP_date(date_and_time):
     """
-    Checks if CacheControl is set in response headers
+    Returns a HTTP-date as defined in rfc7234 section 5.3
+    for a datetime object"""
+    locale.setlocale(locale.LC_ALL, "en_GB.utf8")
+
+    return datetime.astimezone(date_and_time).strftime(
+        "%a, %d %b %Y %H:%M:%S %Z"
+    )
+
+
+def cache_directives_in_headers(headers):
+    """
+    Checks if cache controls are set in response headers
     """
     cache_control = "cache-control" in headers
     pragma = "pragma" in headers and "no-cache" in headers["pragma"]
     expires = "expires" in headers
+
+    return expires or pragma or cache_control
 
 
 class ExpiresAfterIfNoCacheControl(BaseHeuristic):
@@ -31,21 +40,31 @@ class ExpiresAfterIfNoCacheControl(BaseHeuristic):
         self.delta = timedelta(**kw)
 
     def update_headers(self, response):
-        if cache_directives_in_headers(reponse.headers):
+        """
+        If no caching controls are present,
+        a default expires header will be set
+        """
+        if cache_directives_in_headers(response.headers):
             return
 
         expires = expire_after(self.delta)
 
         return {
-            "expires": datetime_to_header(expires),
+            "expires": datetime_to_HTTP_date(expires),
             "cache-control": "public",
         }
 
     def warning(self):
+        """
+        Adds a warning to the response as defined in rfc7234 section 5.5
+        """
         template = "110 - Automatically cached for %s. Response might be stale"
         return template % self.delta
 
     def apply(self, response):
+        """
+        Applies the heuristic to the response
+        """
         updated_headers = self.update_headers(response)
 
         if updated_headers:

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,11 @@ setup(
     ),
     long_description=open("README.rst").read(),
     install_requires=[
-        "requests>=2.21.0",
-        "redis>=3.0.1",
         "CacheControl>=0.12.5",
-        "lockfile>=0.12.2",
         "HTTPretty>=0.9.6",
+        "lockfile>=0.12.2",
+        "mockredispy>=2.9.3",
+        "redis>=3.0.1",
+        "requests>=2.21.0",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     long_description=open("README.rst").read(),
     install_requires=[
         "CacheControl>=0.12.5",
+        "freezegun>=0.3.11",
         "HTTPretty>=0.9.6",
         "lockfile>=0.12.2",
         "mockredispy>=2.9.3",

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
         "redis>=3.0.1",
         "CacheControl>=0.12.5",
         "lockfile>=0.12.2",
+        "HTTPretty>=0.9.6",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,5 @@ setup(
         "redis>=3.0.1",
         "requests>=2.21.0",
     ],
+    test_suite="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,21 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='canonicalwebteam.http',
-    version='0.1.6',
-    author='Canonical webteam',
-    author_email='webteam@canonical.com',
-    url='https://github.com/canonicalwebteam/http',
+    name="canonicalwebteam.http",
+    version="1.0.0",
+    author="Canonical webteam",
+    author_email="webteam@canonical.com",
+    url="https://github.com/canonical-webteam/http",
     packages=find_packages(),
     description=(
         "For making HTTP requests "
         "with helpful defaults for Canonical's webteam."
     ),
-    long_description=open('README.rst').read(),
+    long_description=open("README.rst").read(),
     install_requires=[
-        "requests>=2.10.0",
+        "requests>=2.21.0",
+        "redis>=3.0.1",
+        "CacheControl>=0.12.5",
+        "lockfile>=0.12.2",
     ],
 )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -250,7 +250,7 @@ class TestCachedSession(unittest.TestCase):
 
     def test_timeout_adapter(self):
         session = CachedSession(
-            timeout=1.2, file_cache_directory=file_cache_directory
+            timeout=2, file_cache_directory=file_cache_directory
         )
 
         # this test can be inconsistent on multiple concurrent
@@ -261,7 +261,7 @@ class TestCachedSession(unittest.TestCase):
                 requests.exceptions.ReadTimeout,
             )
         ):
-            session.get("https://httpbin.org/delay/1.5")
+            session.get("https://httpbin.org/delay/3")
 
         resp = session.get("https://httpbin.org/delay/1")
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -216,10 +216,10 @@ class TestCachedSession(unittest.TestCase):
             httpretty.GET, "https://now.httpbin.org", body=request_callback
         )
         session_1 = CachedSession(
-            redis_connection_pool=redis_mock_1, fallback_cache_duration=500
+            redis_connection=redis_mock_1, fallback_cache_duration=500
         )
         session_2 = CachedSession(
-            redis_connection_pool=redis_mock_2, fallback_cache_duration=1
+            redis_connection=redis_mock_2, fallback_cache_duration=1
         )
 
         resp_1 = session_1.get("https://now.httpbin.org")
@@ -234,7 +234,7 @@ class TestCachedSession(unittest.TestCase):
         self.assertNotEqual(resp_2.text, resp_3.text)
 
         session_3 = CachedSession(
-            redis_connection_pool=redis_mock_1, fallback_cache_duration=1
+            redis_connection=redis_mock_1, fallback_cache_duration=1
         )
 
         resp_4 = session_3.get("https://now.httpbin.org")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,46 @@
+import redis
+import unittest
+from cachecontrol.caches.file_cache import FileCache
+from cachecontrol.caches.redis_cache import RedisCache
+from canonicalwebteam.http import CachedSession
+from datetime import timedelta
+from unittest import TestCase
+
+
+def create_redis_connection_pool(
+    redis_port="6379", redis_host="localhost", redis_db=0
+):
+    return redis.ConnectionPool(host=redis_host, port=redis_port, db=redis_db)
+
+
+class TestCachedSession(TestCase):
+    def test_custom_heuristic(self):
+        session = CachedSession(fallback_cache_duration=10)
+        adapter = session.get_adapter("http://")
+        heuristic = adapter.heuristic
+        delta = heuristic.delta
+        self.assertEqual(delta, timedelta(seconds=10))
+
+    def test_default_heuristic(self):
+        session = CachedSession()
+        adapter = session.get_adapter("http://")
+        heuristic = adapter.heuristic
+        delta = heuristic.delta
+        self.assertEqual(delta, timedelta(seconds=5))
+
+    def test_file_cache(self):
+        session = CachedSession()
+        adapter = session.get_adapter("http://")
+        cache = adapter.cache
+        self.assertIsInstance(cache, FileCache)
+
+    def test_redis_cache(self):
+        pool = create_redis_connection_pool()
+        session = CachedSession(redis_cache_pool=pool)
+        adapter = session.get_adapter("http://")
+        cache = adapter.cache
+        self.assertIsInstance(cache, RedisCache)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,20 +1,20 @@
-import httpretty
 import json
 import os
-import pickle
-import redis
-import requests
 import shutil
 import struct
 import time
 import unittest
-from cachecontrol.caches.file_cache import FileCache
-from cachecontrol.caches.redis_cache import RedisCache
-from canonicalwebteam.http import CachedSession
 from datetime import timedelta
-from mockredis import mock_redis_client
 from unittest.mock import patch
 
+import redis
+import requests
+from canonicalwebteam.http import CachedSession
+
+import httpretty
+from cachecontrol.caches.file_cache import FileCache
+from cachecontrol.caches.redis_cache import RedisCache
+from mockredis import mock_redis_client
 
 file_cache_directory = ".testcache"
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,10 +1,16 @@
+import httpretty
+import json
 import redis
+import shutil
+import time
 import unittest
+import requests
 from cachecontrol.caches.file_cache import FileCache
 from cachecontrol.caches.redis_cache import RedisCache
 from canonicalwebteam.http import CachedSession
 from datetime import timedelta
-from unittest import TestCase
+
+file_cache_directory = ".testcache"
 
 
 def create_redis_connection_pool(
@@ -13,33 +19,127 @@ def create_redis_connection_pool(
     return redis.ConnectionPool(host=redis_host, port=redis_port, db=redis_db)
 
 
-class TestCachedSession(TestCase):
+class TestCachedSession(unittest.TestCase):
+    def tearDown(self):
+        try:
+            shutil.rmtree(file_cache_directory)
+        except:
+            pass
+
+    @httpretty.activate
     def test_custom_heuristic(self):
-        session = CachedSession(fallback_cache_duration=10)
-        adapter = session.get_adapter("http://")
-        heuristic = adapter.heuristic
-        delta = heuristic.delta
-        self.assertEqual(delta, timedelta(seconds=10))
+        def request_callback(request, uri, response_headers):
+            return [200, response_headers, json.dumps({"epoch": time.time()})]
 
+        httpretty.register_uri(
+            httpretty.GET, "https://now.httpbin.org", body=request_callback
+        )
+
+        session = CachedSession(
+            fallback_cache_duration=2,
+            file_cache_directory=file_cache_directory,
+        )
+
+        # with a 2s retention, and a 1.1s time between requests, 2 of the
+        # request should have the same epoch, where as the 3rd gets fresh data
+        # the first requests gets send at t=0
+        response = []
+
+        for i in range(3):
+            resp = session.get("https://now.httpbin.org")
+            response.append(resp)
+            time.sleep(1.1)
+
+        self.assertEqual(response[0].text, response[1].text)
+        self.assertNotEqual(response[1].text, response[2].text)
+
+    @httpretty.activate
     def test_default_heuristic(self):
-        session = CachedSession()
-        adapter = session.get_adapter("http://")
-        heuristic = adapter.heuristic
-        delta = heuristic.delta
-        self.assertEqual(delta, timedelta(seconds=5))
+        def request_callback(request, uri, response_headers):
+            return [200, response_headers, json.dumps({"epoch": time.time()})]
 
-    def test_file_cache(self):
-        session = CachedSession()
-        adapter = session.get_adapter("http://")
-        cache = adapter.cache
-        self.assertIsInstance(cache, FileCache)
+        httpretty.register_uri(
+            httpretty.GET, "https://now.httpbin.org", body=request_callback
+        )
 
-    def test_redis_cache(self):
-        pool = create_redis_connection_pool()
-        session = CachedSession(redis_cache_pool=pool)
-        adapter = session.get_adapter("http://")
-        cache = adapter.cache
-        self.assertIsInstance(cache, RedisCache)
+        session = CachedSession(file_cache_directory=file_cache_directory)
+
+        # with default 5s retention, and a 2.6s time between requests, 2 of the
+        # request should have the same epoch, where as the 3rd gets fresh data
+        # the first requests gets send at t=0
+        response = []
+
+        for i in range(3):
+            resp = session.get("https://now.httpbin.org")
+            response.append(resp)
+            time.sleep(2.6)
+
+        self.assertEqual(response[0].text, response[1].text)
+        self.assertNotEqual(response[1].text, response[2].text)
+
+    @httpretty.activate
+    def test_cache_control_max_age_overwrites_custom_heuristic(self):
+        def request_callback(request, uri, response_headers):
+            return [200, response_headers, json.dumps({"epoch": time.time()})]
+
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://now.httpbin.org",
+            body=request_callback,
+            adding_headers={"Cache-Control": "max-age=3"},
+        )
+
+        session = CachedSession(file_cache_directory=file_cache_directory)
+
+        # with 3s retention from CC, and a 1.6s time between requests, 2 of the
+        # request should have the same epoch, where as the 3rd gets fresh data
+        # the first requests gets send at t=0
+        response = []
+
+        for i in range(3):
+            resp = session.get("https://now.httpbin.org")
+            response.append(resp)
+            time.sleep(1.6)
+
+        self.assertEqual(response[0].text, response[1].text)
+        self.assertNotEqual(response[1].text, response[2].text)
+
+    @httpretty.activate
+    def test_cache_control_no_cache_overwrites_custom_heuristic(self):
+        def request_callback(request, uri, response_headers):
+            return [200, response_headers, json.dumps({"epoch": time.time()})]
+
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://now.httpbin.org",
+            body=request_callback,
+            adding_headers={"Cache-Control": "no-cache"},
+        )
+        session = CachedSession(file_cache_directory=file_cache_directory)
+
+        # with no-cache set, no request should be cached,
+        # thus all bodies are different
+        response = []
+
+        for i in range(3):
+            resp = session.get("https://now.httpbin.org")
+            response.append(resp)
+
+        self.assertNotEqual(response[0].text, response[1].text)
+        self.assertNotEqual(response[1].text, response[2].text)
+
+    # def test_file_cache(self):
+    #     session = CachedSession()
+    #     adapter = session.get_adapter("http://")
+    #     cache = adapter.cache
+    #     self.assertIsInstance(cache, FileCache)
+
+    # def test_redis_cache(self):
+    #     pool = create_redis_connection_pool()
+    #     session = CachedSession(redis_cache_pool=pool)
+    #     adapter = session.get_adapter("http://")
+    #     cache = adapter.cache
+    #     self.assertIsInstance(cache, RedisCache)
 
 
 if __name__ == "__main__":

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,0 +1,42 @@
+import locale
+import unittest
+from datetime import datetime, timedelta
+
+from canonicalwebteam.http import heuristics
+
+
+class TestHeuristics(unittest.TestCase):
+    def test_custom_heuristic(self):
+        today = datetime.utcnow()
+        one_day_delta = timedelta(days=1)
+        tomorrow = today + one_day_delta
+
+        self.assertEqual(
+            tomorrow, heuristics.expire_after(one_day_delta, today)
+        )
+
+    def test_datetime_to_header_string(self):
+        locale.setlocale(locale.LC_ALL, "en_GB.utf8")
+        date_string = "Thu, 01 Dec 1994 16:00:00 GMT"
+        date = datetime.strptime(date_string, "%a, %d %b %Y %H:%M:%S %Z")
+
+        self.assertEqual(date_string, heuristics.datetime_to_HTTP_date(date))
+
+    def test_cache_directives_in_headers(self):
+        headers = {}
+
+        self.assertEqual(
+            heuristics.cache_directives_in_headers(headers), False
+        )
+
+        headers = {"expires": "1"}
+
+        self.assertEqual(heuristics.cache_directives_in_headers(headers), True)
+
+        headers = {"pragma": "no-cache"}
+
+        self.assertEqual(heuristics.cache_directives_in_headers(headers), True)
+
+        headers = {"cache-control": "yeah"}
+
+        self.assertEqual(heuristics.cache_directives_in_headers(headers), True)


### PR DESCRIPTION
## DONE
Implements 1 part of https://github.com/ubuntudesign/base-squad/issues/119
Fixes #5, #6 

## QA
Here is a test script to make sure that the code works.
This needs a Redis server running at the standard config locally.
```python
import time
import redis
from cachecontrol.caches.file_cache import FileCache
from cachecontrol.caches.redis_cache import RedisCache
from canonicalwebteam.http import CachedSession
from datetime import datetime


def create_redis_connection_pool(
    redis_port="6379", redis_host="localhost", redis_db=0
):
    return redis.ConnectionPool(host=redis_host, port=redis_port, db=redis_db)


pool = create_redis_connection_pool()
sess = CachedSession(redis_cache_pool=pool, fallback_cache_duration=10)
print(sess)
for i in range(9):
    print("start")
    print(datetime.now())
    response = sess.get("https://ehlers.berlin")

    print("is response from cache")
    print(response.from_cache)
    print(datetime.now())
    print(response.headers)
    time.sleep(10)
```