### PR TITLE
Use system default locale

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,3 +7,4 @@ v0.1.4, 2018-07-10 -- More python2 support
 v0.1.5, 2018-07-10 -- Ditto
 v0.1.6, 2018-08-01 -- Fix "domain undefined" error
 v1.0.0, 2019-01-16 -- Adds CacheControl awareness to cached sessions
+v1.0.1, 2019-02-14 -- Uses sytem locale instead of setting explicitely

--- a/canonicalwebteam/http/heuristics.py
+++ b/canonicalwebteam/http/heuristics.py
@@ -13,7 +13,7 @@ def datetime_to_HTTP_date(date_and_time):
     """
     Returns a HTTP-date as defined in rfc7234 section 5.3
     for a datetime object"""
-    locale.setlocale(locale.LC_ALL, "en_GB.utf8")
+    locale.setlocale(locale.LC_ALL, "")
 
     return datetime.astimezone(date_and_time).strftime(
         "%a, %d %b %Y %H:%M:%S %Z"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.http",
-    version="1.0.0",
+    version="1.0.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/http",


### PR DESCRIPTION
Currently `en_GB.utf-8` out of LC_ALL is used as a locale. If a system is configured without this locale, the requests will crash.

Changing this to use the default locale instead. 