### PR TITLE
Add circuit breaker to BaseSession

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.http",
-    version="1.0.1",
+    version="1.1.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/http",
@@ -21,6 +21,7 @@ setup(
         "HTTPretty>=0.9.6",
         "lockfile>=0.12.2",
         "mockredispy>=2.9.3",
+        "pybreaker >=0.5.0",
         "redis>=3.0.1",
         "requests>=2.21.0",
     ],

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+
+from pybreaker import CircuitBreakerError
+from requests.exceptions import HTTPError
+from canonicalwebteam.http import BaseSession
+
+
+def call_and_ignore_exceptions(fn, *args):
+    try:
+        fn(*args)
+    except HTTPError:
+        pass
+
+
+class TestCircuitBreaker(unittest.TestCase):
+    @patch("requests.Session.request")
+    def test_circuit_opens(self, request_mock):
+        request_mock.side_effect = HTTPError()
+        session = BaseSession()
+
+        for _ in range(4):
+            call_and_ignore_exceptions(session.get, "https://httpbin.org")
+
+        with self.assertRaises(CircuitBreakerError):
+            session.get("https://httpbin.org")


### PR DESCRIPTION
Adds a circuit-breaker to disable session requests after 5 consecutive failures. Closes the circuit again after 60 seconds.

Fixes #11 