### PR TITLE
Explicitly install filecache dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     install_requires=[
-        "CacheControl>=0.12.5",
+        "CacheControl[filecache]>=0.12.5",
         "freezegun>=0.3.11",
         "HTTPretty>=1.0.2",
         "lockfile>=0.12.2",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.http",
-    version="1.0.3",
+    version="1.0.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/http",


### PR DESCRIPTION
This should then bring in filelock as required for filecache to work.

The "filecache" extra for CacheControl should lead to the correct dependencies being installed.

Fixes https://warthogs.atlassian.net/browse/WD-4362

## QA

See if https://maas-io-790.demos.haus/ loads.